### PR TITLE
Improve error message when the type is not bytes

### DIFF
--- a/base58.py
+++ b/base58.py
@@ -30,6 +30,9 @@ else:  # python3
 def b58encode(v):
     '''Encode a string using Base58'''
 
+    if not isinstance(v, bytes):
+        raise TypeError("a bytes-like object is required, not 'str'")
+
     origlen = len(v)
     v = v.lstrip(b'\0')
     newlen = len(v)


### PR DESCRIPTION
Fixes #5 
This work on both Python 2 and 3 but I'm not sure what a proper test for it.

A simple test like this would work in py3 but fails in py2 because `data` is both `str` and `bytes`:
```
def test_input_should_be_bytes():
     data = '3vQB7B6MrGQZaxCuFg4oH'
     with assert_raises(TypeError):
         b58encode(data)
```