### PR TITLE
allow for input string in b58encode

### DIFF
--- a/base58.py
+++ b/base58.py
@@ -40,8 +40,12 @@ def b58encode_int(i, default_one=True):
 
 def b58encode(v):
     '''Encode a string using Base58'''
+
+    if isinstance(v, str):
+        v = v.encode('ascii')
+        
     if not isinstance(v, bytes):
-        raise TypeError("a bytes-like object is required, not '%s'" %
+        raise TypeError("a bytes-like object is required (also str), not '%s'" %
                         type(v).__name__)
 
     origlen = len(v)

--- a/test.py
+++ b/test.py
@@ -28,13 +28,28 @@ def test_simple_encode():
     assert_that(data, equal_to('StV1DL6CwTryKyV'))
 
 
+def test_simple_encode_str():
+    data = b58encode('hello world')
+    assert_that(data, equal_to('StV1DL6CwTryKyV'))
+
+
 def test_leadingz_encode():
     data = b58encode(b'\0\0hello world')
     assert_that(data, equal_to('11StV1DL6CwTryKyV'))
 
 
-def test_encode_empty():
+def test_leadingz_encode_str():
+    data = b58encode('\0\0hello world')
+    assert_that(data, equal_to('11StV1DL6CwTryKyV'))
+
+
+def test_empty_encode():
     data = b58encode(b'')
+    assert_that(data, equal_to(''))
+
+
+def test_empty_encode_str():
+    data = b58encode('')
     assert_that(data, equal_to(''))
 
 


### PR DESCRIPTION
Allowing for input string in b58encode would permit
```
    b58encode("hello world")
    b58decode(b58encode("hello world"))==b'hello world'
```
and
```
    b58encode("\0\0hello world"))
    b58decode(b58encode("\0\0hello world"))==b'\0\0hello world'
```

Also, this behavior would just mirror the b58decode ability to process both strings and bytes