### PR TITLE
Add the packaging metadata to build the base58 snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: base58
+version: git
+summary: Base58 and Base58Check implementation
+description: |
+  Base58 and Base58Check implementation compatible with what is used by the
+  bitcoin network.
+
+grade: stable
+confinement: strict
+
+apps:
+  base58:
+    command: base58
+
+parts:
+  base58:
+    source: .
+    plugin: python


### PR DESCRIPTION
This package will let you publish the latest base58 in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.