### PR TITLE
Enhance/add alphabet param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "pypy2.7-6.0"
+    - "pypy2.7-5.10.0"
     - "pypy3.5-6.0"
 install:
     - pip install -r test-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "pypy"
-    - "pypy3"
+    - "pypy2.7-6.0"
+    - "pypy3.5-6.0"
 install:
     - pip install -r test-requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "pypy2.7-5.10.0"
     - "pypy3.5-6.0"
 install:
     - pip install -r test-requirements.txt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Coverage Status][coveralls-image]](https://coveralls.io/r/keis/base58?branch=master)
 
 Base58 and Base58Check implementation compatible with what is used by the
-bitcoin network.
+bitcoin network. Any other alternative alphabet (like the Ripple one) can be used.
 
 
 ## Command line usage
@@ -41,6 +41,11 @@ bitcoin network.
       File "base58.py", line 89, in b58decode_check
         raise ValueError("Invalid checksum")
     ValueError: Invalid checksum
+    # Use another alphabet. Here, using the built-in Ripple alphabet.
+    >>> base58.b58encode(b'hello world', alphabet=base58.RIPPLE_ALPHABET)
+    'StVrDLaUATiyKyV'
+    >>> base58.b58decode(b'StVrDLaUATiyKyV', alphabet=base58.RIPPLE_ALPHABET)
+    b'hello world'
 
 
 [pypi-image]: https://img.shields.io/pypi/v/base58.svg?style=flat

--- a/base58.py
+++ b/base58.py
@@ -14,7 +14,8 @@ from hashlib import sha256
 __version__ = '1.0.3'
 
 # 58 character alphabet used
-BITCOIN_ALPHABET = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+BITCOIN_ALPHABET = \
+    b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 RIPPLE_ALPHABET = b'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz'
 
 

--- a/base58.py
+++ b/base58.py
@@ -18,6 +18,9 @@ BITCOIN_ALPHABET = \
     b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 RIPPLE_ALPHABET = b'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz'
 
+# Retro compatibility
+alphabet = BITCOIN_ALPHABET
+
 
 if bytes == str:  # python2
     iseq, bseq, buffer = (

--- a/base58.py
+++ b/base58.py
@@ -14,7 +14,8 @@ from hashlib import sha256
 __version__ = '1.0.3'
 
 # 58 character alphabet used
-alphabet = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+BITCOIN_ALPHABET = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+RIPPLE_ALPHABET = b'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz'
 
 
 if bytes == str:  # python2
@@ -38,8 +39,10 @@ def scrub_input(v):
     return v
 
 
-def b58encode_int(i, default_one=True):
-    '''Encode an integer using Base58'''
+def b58encode_int(i, default_one=True, alphabet=BITCOIN_ALPHABET):
+    """
+    Encode an integer using Base58
+    """
     if not i and default_one:
         return alphabet[0:1]
     string = b""
@@ -49,8 +52,10 @@ def b58encode_int(i, default_one=True):
     return string
 
 
-def b58encode(v):
-    '''Encode a string using Base58'''
+def b58encode(v, alphabet=BITCOIN_ALPHABET):
+    """
+    Encode a string using Base58
+    """
     v = scrub_input(v)
 
     nPad = len(v)
@@ -61,14 +66,14 @@ def b58encode(v):
     for c in iseq(reversed(v)):
         acc += p * c
         p = p << 8
-
-    result = b58encode_int(acc, default_one=False)
-
-    return (alphabet[0:1] * nPad + result)
+    result = b58encode_int(acc, default_one=False, alphabet=alphabet)
+    return alphabet[0:1] * nPad + result
 
 
-def b58decode_int(v):
-    '''Decode a Base58 encoded string as an integer'''
+def b58decode_int(v, alphabet=BITCOIN_ALPHABET):
+    """
+    Decode a Base58 encoded string as an integer
+    """
     v = v.rstrip()
     v = scrub_input(v)
 
@@ -78,8 +83,10 @@ def b58decode_int(v):
     return decimal
 
 
-def b58decode(v):
-    '''Decode a Base58 encoded string'''
+def b58decode(v, alphabet=BITCOIN_ALPHABET):
+    """
+    Decode a Base58 encoded string
+    """
     v = v.rstrip()
     v = scrub_input(v)
 
@@ -87,27 +94,29 @@ def b58decode(v):
     v = v.lstrip(alphabet[0:1])
     newlen = len(v)
 
-    acc = b58decode_int(v)
+    acc = b58decode_int(v, alphabet=alphabet)
 
     result = []
     while acc > 0:
         acc, mod = divmod(acc, 256)
         result.append(mod)
 
-    return (b'\0' * (origlen - newlen) + bseq(reversed(result)))
+    return b'\0' * (origlen - newlen) + bseq(reversed(result))
 
 
-def b58encode_check(v):
-    '''Encode a string using Base58 with a 4 character checksum'''
+def b58encode_check(v, alphabet=BITCOIN_ALPHABET):
+    """
+    Encode a string using Base58 with a 4 character checksum
+    """
 
     digest = sha256(sha256(v).digest()).digest()
-    return b58encode(v + digest[:4])
+    return b58encode(v + digest[:4], alphabet=alphabet)
 
 
-def b58decode_check(v):
+def b58decode_check(v, alphabet=BITCOIN_ALPHABET):
     '''Decode and verify the checksum of a Base58 encoded string'''
 
-    result = b58decode(v)
+    result = b58decode(v, alphabet=alphabet)
     result, check = result[:-4], result[-4:]
     digest = sha256(sha256(result).digest()).digest()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 pytest
 pytest-pep8
 pytest-flakes
+# Open issue: https://github.com/z4r/python-coveralls/issues/66
 pytest-cov<=2.6.0
 PyHamcrest
 mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,7 @@
-# Quick fix: https://github.com/pytest-dev/pytest/issues/4608
-pytest==4.02
+pytest
 pytest-pep8
 pytest-flakes
-# Open issue: https://github.com/z4r/python-coveralls/issues/66
-pytest-cov<=2.6.0
+pytest-cov
 PyHamcrest
 mock
 matchmock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
-pytest
+# Quick fix: https://github.com/pytest-dev/pytest/issues/4608
+pytest==4.02
 pytest-pep8
 pytest-flakes
 # Open issue: https://github.com/z4r/python-coveralls/issues/66

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-pep8
 pytest-flakes
-pytest-cov
+pytest-cov<=2.6.0
 PyHamcrest
 mock
 matchmock

--- a/test_base58.py
+++ b/test_base58.py
@@ -3,7 +3,7 @@ from itertools import product
 from hamcrest import assert_that, equal_to, instance_of
 from base58 import (
     b58encode, b58decode, b58encode_check, b58decode_check, b58encode_int,
-    b58decode_int, BITCOIN_ALPHABET)
+    b58decode_int, BITCOIN_ALPHABET, alphabet)
 
 
 if bytes == str:
@@ -112,3 +112,7 @@ def test_large_integer():
     number = 0x111d38e5fc9071ffcd20b4a763cc9ae4f252bb4e48fd66a835e252ada93ff480d6dd43dc62a641155a5  # noqa
     assert_that(b58decode_int(BITCOIN_ALPHABET), equal_to(number))
     assert_that(b58encode_int(number), equal_to(BITCOIN_ALPHABET[1:]))
+
+
+def test_alphabet_alias_exists_and_equals_bitcoin_alphabet():
+    assert_that(alphabet, BITCOIN_ALPHABET)

--- a/test_base58.py
+++ b/test_base58.py
@@ -3,7 +3,7 @@ from itertools import product
 from hamcrest import assert_that, equal_to, instance_of
 from base58 import (
     b58encode, b58decode, b58encode_check, b58decode_check, b58encode_int,
-    b58decode_int, alphabet)
+    b58decode_int, BITCOIN_ALPHABET)
 
 
 if bytes == str:
@@ -102,7 +102,7 @@ def test_round_trips():
 
 
 def test_simple_integers():
-    for idx, char in enumerate(alphabet):
+    for idx, char in enumerate(BITCOIN_ALPHABET):
         char = bytes_from_char(char)
         assert_that(b58decode_int(char), equal_to(idx))
         assert_that(b58encode_int(idx), equal_to(char))
@@ -110,5 +110,5 @@ def test_simple_integers():
 
 def test_large_integer():
     number = 0x111d38e5fc9071ffcd20b4a763cc9ae4f252bb4e48fd66a835e252ada93ff480d6dd43dc62a641155a5  # noqa
-    assert_that(b58decode_int(alphabet), equal_to(number))
-    assert_that(b58encode_int(number), equal_to(alphabet[1:]))
+    assert_that(b58decode_int(BITCOIN_ALPHABET), equal_to(number))
+    assert_that(b58encode_int(number), equal_to(BITCOIN_ALPHABET[1:]))


### PR DESCRIPTION
This PR adds the possibility to specify different alphabet in the functions to include, for example, the ripple base58 alphabet: https://developers.ripple.com/base58-encodings.html

I also renamed for more clarity the `alphabet` module variable in `BITCOIN_ALPHABET`, and add the ripple alphabet too.

I suggest to update the version to 1.1.0 as it could break if people uses `base58.alphabet`