### PR TITLE
Type annotate public API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
         pip install mypy &&
         mypy .
       fi
-    - mypy .
     - pytest --flake8 --cov=base58 .
 after_success:
     coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 install:
     - pip install -r test-requirements.txt
 script:
-    pytest --pep8 --flakes --cov=base58 .
+    - mypy .
+    - pytest --flake8 --cov=base58 .
 after_success:
     coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,17 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
-    - "pypy3.5-6.0"
+    - "pypy3.5-7.0.0"
+    - "pypy3.6-7.1.1"
 install:
     - pip install -r test-requirements.txt
 script:
+    # Only run mypy in "3.5" job, because installing it fails in PyPy jobs
+    - |
+      if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then
+        pip install mypy &&
+        mypy .
+      fi
     - mypy .
     - pytest --flake8 --cov=base58 .
 after_success:

--- a/base58.py
+++ b/base58.py
@@ -10,6 +10,7 @@ with the bitcoin network.
 # This module adds shiny packaging and support for python3.
 
 from hashlib import sha256
+from typing import Union
 
 __version__ = '1.0.3'
 
@@ -22,14 +23,16 @@ RIPPLE_ALPHABET = b'rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz'
 alphabet = BITCOIN_ALPHABET
 
 
-def scrub_input(v):
+def scrub_input(v: Union[str, bytes]) -> bytes:
     if isinstance(v, str):
         v = v.encode('ascii')
 
     return v
 
 
-def b58encode_int(i, default_one=True, alphabet=BITCOIN_ALPHABET):
+def b58encode_int(
+    i: int, default_one: bool = True, alphabet: bytes = BITCOIN_ALPHABET
+) -> bytes:
     """
     Encode an integer using Base58
     """
@@ -42,7 +45,9 @@ def b58encode_int(i, default_one=True, alphabet=BITCOIN_ALPHABET):
     return string
 
 
-def b58encode(v, alphabet=BITCOIN_ALPHABET):
+def b58encode(
+    v: Union[str, bytes], alphabet: bytes = BITCOIN_ALPHABET
+) -> bytes:
     """
     Encode a string using Base58
     """
@@ -60,7 +65,9 @@ def b58encode(v, alphabet=BITCOIN_ALPHABET):
     return alphabet[0:1] * nPad + result
 
 
-def b58decode_int(v, alphabet=BITCOIN_ALPHABET):
+def b58decode_int(
+    v: Union[str, bytes], alphabet: bytes = BITCOIN_ALPHABET
+) -> int:
     """
     Decode a Base58 encoded string as an integer
     """
@@ -73,7 +80,9 @@ def b58decode_int(v, alphabet=BITCOIN_ALPHABET):
     return decimal
 
 
-def b58decode(v, alphabet=BITCOIN_ALPHABET):
+def b58decode(
+    v: Union[str, bytes], alphabet: bytes = BITCOIN_ALPHABET
+) -> bytes:
     """
     Decode a Base58 encoded string
     """
@@ -94,7 +103,7 @@ def b58decode(v, alphabet=BITCOIN_ALPHABET):
     return b'\0' * (origlen - newlen) + bytes(reversed(result))
 
 
-def b58encode_check(v, alphabet=BITCOIN_ALPHABET):
+def b58encode_check(v: bytes, alphabet: bytes = BITCOIN_ALPHABET) -> bytes:
     """
     Encode a string using Base58 with a 4 character checksum
     """
@@ -103,7 +112,9 @@ def b58encode_check(v, alphabet=BITCOIN_ALPHABET):
     return b58encode(v + digest[:4], alphabet=alphabet)
 
 
-def b58decode_check(v, alphabet=BITCOIN_ALPHABET):
+def b58decode_check(
+    v: Union[str, bytes], alphabet: bytes = BITCOIN_ALPHABET
+) -> bytes:
     '''Decode and verify the checksum of a Base58 encoded string'''
 
     result = b58decode(v, alphabet=alphabet)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,14 @@
+[mypy]
+warn_unreachable = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_unused_configs = True
+; Disabling incremental mode is required for `warn_unused_configs = True` to work
+incremental = False
+
+
+[mypy-hamcrest.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 pytest
-pytest-pep8
-pytest-flakes
+pytest-flake8
 pytest-cov
 PyHamcrest
 coveralls
+mypy

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,3 @@ pytest-flake8
 pytest-cov
 PyHamcrest
 coveralls
-mypy


### PR DESCRIPTION
- Type annotate the public API
- Lint with mypy
- Use pytest-flake8 instead of pytest-flakes and pytest-pep8. The latter are unmaintained and dont support new type annoatation syntax.
- Add CI job for pypy3.6

This PR does NOT:
- Implement PEP561, i.e. distribute type data. I can do this in a follow up PR.