### PR TITLE
Distribute type data (PEP 561)

### DIFF
--- a/base58/__init__.py
+++ b/base58/__init__.py
@@ -1,6 +1,6 @@
 '''Base58 encoding
 
-Implementations of Base58 and Base58Check endcodings that are compatible
+Implementations of Base58 and Base58Check encodings that are compatible
 with the bitcoin network.
 '''
 
@@ -128,49 +128,3 @@ def b58decode_check(
         raise ValueError("Invalid checksum")
 
     return result
-
-
-def main():
-    '''Base58 encode or decode FILE, or standard input, to standard output.'''
-
-    import sys
-    import argparse
-
-    stdout = sys.stdout.buffer
-
-    parser = argparse.ArgumentParser(description=main.__doc__)
-    parser.add_argument(
-        'file',
-        metavar='FILE',
-        nargs='?',
-        type=argparse.FileType('r'),
-        default='-')
-    parser.add_argument(
-        '-d', '--decode',
-        action='store_true',
-        help='decode data')
-    parser.add_argument(
-        '-c', '--check',
-        action='store_true',
-        help='append a checksum before encoding')
-
-    args = parser.parse_args()
-    fun = {
-        (False, False): b58encode,
-        (False, True): b58encode_check,
-        (True, False): b58decode,
-        (True, True): b58decode_check
-    }[(args.decode, args.check)]
-
-    data = args.file.buffer.read()
-
-    try:
-        result = fun(data)
-    except Exception as e:
-        sys.exit(e)
-
-    stdout.write(result)
-
-
-if __name__ == '__main__':
-    main()

--- a/base58/__main__.py
+++ b/base58/__main__.py
@@ -1,0 +1,47 @@
+import argparse
+import sys
+
+from base58 import b58decode, b58decode_check, b58encode, b58encode_check
+
+
+def main():
+    '''Base58 encode or decode FILE, or standard input, to standard output.'''
+
+    stdout = sys.stdout.buffer
+
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument(
+        'file',
+        metavar='FILE',
+        nargs='?',
+        type=argparse.FileType('r'),
+        default='-')
+    parser.add_argument(
+        '-d', '--decode',
+        action='store_true',
+        help='decode data')
+    parser.add_argument(
+        '-c', '--check',
+        action='store_true',
+        help='append a checksum before encoding')
+
+    args = parser.parse_args()
+    fun = {
+        (False, False): b58encode,
+        (False, True): b58encode_check,
+        (True, False): b58decode,
+        (True, True): b58decode_check
+    }[(args.decode, args.check)]
+
+    data = args.file.buffer.read()
+
+    try:
+        result = fun(data)
+    except Exception as e:
+        sys.exit(e)
+
+    stdout.write(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/base58/py.typed
+++ b/base58/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,18 @@ from setuptools import setup
 
 setup(
     name='base58',
-    py_modules=['base58'],
+    packages=['base58'],
+    package_data={'base58': ['py.typed']},
     version='1.0.3',
     description='Base58 and Base58Check implementation',
     author='David Keijser',
     author_email='keijser@gmail.com',
     url='https://github.com/keis/base58',
     license='MIT',
+    zip_safe=False,  # mypy needs this to be able to find the package
     entry_points={
         'console_scripts': [
-            'base58 = base58:main'
+            'base58 = base58.__main__:main'
         ]
     },
     python_requires=">=3.5",


### PR DESCRIPTION
Note that I had to place `base58.py` in a package. Quoting https://www.python.org/dev/peps/pep-0561/ :
> This PEP does not support distributing typing information as part of module-only distributions.