### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: xenial
 language: python
+arch: 
+    - amd64
+    - ppc64le
 python:
     - "3.5"
     - "3.6"
@@ -7,6 +10,12 @@ python:
     - "3.8"
     - "pypy3.5-7.0.0"
     - "pypy3.6-7.1.1"
+jobs:
+    exclude:
+      - arch: ppc64le
+        python: pypy3.5-7.0.0
+      - arch: ppc64le
+        python: pypy3.6-7.1.1
 install:
     - pip install -r test-requirements.txt
 script:


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues 
or failures early would help to ensure that we are always up to date.