### PR TITLE
Escape illegal special characters in error message

### DIFF
--- a/base58/__init__.py
+++ b/base58/__init__.py
@@ -102,7 +102,7 @@ def b58decode_int(
             decimal = decimal * base + map[char]
     except KeyError as e:
         raise ValueError(
-            "Invalid character <{char}>".format(char=chr(e.args[0]))
+            "Invalid character {!r}".format(chr(e.args[0]))
         ) from None
     return decimal
 

--- a/test_base45.py
+++ b/test_base45.py
@@ -87,4 +87,4 @@ def test_invalid_input():
     data = 'xyz0'   # 0 is not part of the bitcoin base58 alphabet
     assert_that(
         calling(b58decode).with_args(data),
-        raises(ValueError, 'Invalid character <0>'))
+        raises(ValueError, "Invalid character '0'"))

--- a/test_base58.py
+++ b/test_base58.py
@@ -128,10 +128,10 @@ def test_large_integer():
 
 
 def test_invalid_input():
-    data = 'xyz0'   # 0 is not part of the bitcoin base58 alphabet
+    data = 'xyz\b'   # backspace is not part of the bitcoin base58 alphabet
     assert_that(
         calling(b58decode).with_args(data),
-        raises(ValueError, 'Invalid character <0>'))
+        raises(ValueError, "Invalid character '\\\\x08'"))
 
 
 @pytest.mark.parametrize('length', [8, 32, 256, 1024])


### PR DESCRIPTION
Consider e.g. the illegal backspace char `\u0008` in an error message.
Previously we'd get:
```
"Invalid character >"
```
with this PR we get
```
"Invalid character '\x08'"
```