### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,12 +6,12 @@ jobs:
     name: Publish package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Install pypa/build
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,23 +4,42 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Run tests
+    name: Unit Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install '.[tests]'
+
+      - name: Run tests
+        run: |
+          pytest --cov=base58 --benchmark-disable .
+
+  mypy:
+    name: MyPy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
 
       - name: Install dependencies
         run: |
@@ -30,6 +49,20 @@ jobs:
         run: |
           mypy . --exclude build
 
-      - name: Run tests
+  flake8:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
         run: |
-          pytest --flake8 --cov=base58 --benchmark-disable .
+          pip install '.[tests]'
+
+      - name: Run flake8
+        uses: py-actions/flake8@v2

--- a/base58/__main__.py
+++ b/base58/__main__.py
@@ -6,12 +6,12 @@ from typing import Callable, Dict, Tuple
 
 from base58 import b58decode, b58decode_check, b58encode, b58encode_check
 
-_fmap = {
+_fmap: Dict[Tuple[bool, bool], Callable[[bytes], bytes]] = {
     (False, False): b58encode,
     (False, True): b58encode_check,
     (True, False): b58decode,
     (True, True): b58decode_check
-}  # type: Dict[Tuple[bool, bool], Callable[[bytes], bytes]]
+}
 
 
 def main() -> None:

--- a/base58/__main__.py
+++ b/base58/__main__.py
@@ -47,7 +47,7 @@ def main() -> None:
     try:
         result = fun(data)
     except Exception as e:
-        sys.exit(e)
+        sys.exit(str(e))
 
     stdout.write(result)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 [options]
 packages = base58
 zip_safe = False
-python_requires = >=3.5
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =
@@ -32,12 +32,12 @@ base58 = py.typed
 
 [options.extras_require]
 tests =
+    flake8
 	mypy
 	PyHamcrest>=2.0.2
 	pytest>=4.6
 	pytest-benchmark
 	pytest-cov
-	pytest-flake8
 
 [bumpversion:file:setup.cfg]
 


### PR DESCRIPTION
* Use new versions of checkout and setup-python
* Update python test matrix adding version 3.11 and removing 3.6, move
  minimum python version accordingly
* Split unit test job from flake8 and mypy analysis
* Explicitly stringify sys.exit parameter to appease mypy
* Use modern type hints to appease flake8