### PR TITLE
Use int.to_bytes to speed up decoding

### DIFF
--- a/base58/__init__.py
+++ b/base58/__init__.py
@@ -123,12 +123,7 @@ def b58decode(
 
     acc = b58decode_int(v, alphabet=alphabet, autofix=autofix)
 
-    result = []
-    while acc > 0:
-        acc, mod = divmod(acc, 256)
-        result.append(mod)
-
-    return b'\0' * (origlen - newlen) + bytes(reversed(result))
+    return acc.to_bytes(origlen - newlen + (acc.bit_length() + 7) // 8, 'big')
 
 
 def b58encode_check(


### PR DESCRIPTION
Lifting part of #70 

Did benchmarks with `pytest -k 'test_decode_random' --benchmark-max-time=10 --benchmark-autosave` reruns show quite some difference in runs on longer data but this change consistently beats the old method.

0006 is from current master, 0009 is with this patch

```
Name (time in us)                                  Min                   Max                  Mean              StdDev                Median                 IQR             Outliers           OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_decode_random[8] (0009_09bbb05)            1.9319 (1.0)         43.0930 (1.0)          2.6994 (1.0)        1.6113 (1.0)          2.1090 (1.0)        0.2910 (3.73)   27233;32164  370,454.0210 (1.0)      239178           1
test_decode_random[8] (0006_578b01f)            3.2480 (1.68)        84.7890 (1.97)         4.0059 (1.48)       1.9595 (1.22)         3.4380 (1.63)       0.2950 (3.78)   17721;44521  249,633.8634 (0.67)     260437           1
test_decode_random[32] (0009_09bbb05)           4.7771 (2.47)       538.9240 (12.51)        5.5988 (2.07)       2.6364 (1.64)         4.9809 (2.36)       0.0780 (1.0)    55328;141858  178,609.6576 (0.48)     934847           1
test_decode_random[32] (0006_578b01f)           9.6110 (4.97)       534.5290 (12.40)       11.1709 (4.14)       4.0129 (2.49)         9.8980 (4.69)       0.3449 (4.42)   20132;69952   89,518.2111 (0.24)     339237           1
test_decode_random[256] (0009_09bbb05)         44.2620 (22.91)      563.8010 (13.08)       53.0820 (19.66)     17.8012 (11.05)       45.3601 (21.51)      7.5930 (97.35)    7471;9157   18,838.7910 (0.05)      85183           1
test_decode_random[256] (0006_578b01f)        153.7560 (79.59)      680.9130 (15.80)      190.0000 (70.39)     45.1139 (28.00)      176.1965 (83.55)     47.6551 (610.98)   4521;2708    5,263.1585 (0.01)      39546           1
test_decode_random[1024] (0009_09bbb05)       387.7309 (200.70)   1,133.3140 (26.30)      446.1720 (165.29)    77.0297 (47.81)      411.7080 (195.22)    49.8960 (639.71)   2529;2453    2,241.2879 (0.01)      20401           1
test_decode_random[1024] (0006_578b01f)     1,822.5090 (943.37)   4,125.0370 (95.72)    2,737.7037 (>1000.0)  403.5820 (250.47)   2,687.3620 (>1000.0)  614.8642 (>1000.0)     1391;6      365.2696 (0.00)       4109           1
```